### PR TITLE
Увеличить модальное окно, пофиксить размытие

### DIFF
--- a/assets/components/frontendmanager/css/web/frontend.css
+++ b/assets/components/frontendmanager/css/web/frontend.css
@@ -134,14 +134,13 @@ body.fm-hide .fm-panel a.fm-mode {
 }
 
 .fm-modal .fm-iframe-wrapper {
-    width: 80vw;
-    height: 80vh;
     border: 0;
     position: absolute;
     background-color: var(--fm-color-primary);
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    top: 10px;
+    left: 10px;
+    right: 50px;
+    bottom: 10px;
     border-radius: .4em;
 }
 
@@ -162,14 +161,14 @@ body.fm-hide .fm-panel a.fm-mode {
 
 .fm-modal .fm-btn-close {
     position: absolute;
-    right: 1.25em;
-    top: 1.25em;
+    right: 10px;
+    top: 10px;
     background-color: var(--fm-color-primary);
     color: white;
     border: none;
     border-radius: 50%;
-    width: 2.5em;
-    height: 2.5em;
+    width: 30px;
+    height: 30px;
     padding: .125em;
     z-index: calc(var(--fm-index) + 2);
     transition: background-color .3s;


### PR DESCRIPTION
Из-за выравнивания модального окна по центру экрана в помощью transition на некоторых устройствах содержимое iframe размывается. Кроме того, удобнее работать с большим модальным окном, оставив минимальные поля для закрытия. 

Сделал фиксированный размер кнопки закрытия, выравнивание модального окна в центре путем указания top, right, bottom и left.